### PR TITLE
Hashing: Avx-256 implementation

### DIFF
--- a/benchmarks/hashing.cpp
+++ b/benchmarks/hashing.cpp
@@ -171,7 +171,6 @@ struct x86_128_hash {
 };
 BENCHMARK(BM_hashing<x86_128_hash>)->BM_ARGS;
 
-
 struct x86_256_hash {
   using VecT = __m256i;
   static constexpr size_t KEYS_PER_ITERATION = sizeof(VecT) / sizeof(KeyT);


### PR DESCRIPTION
Also reverted to return-by-value so we don't have to think about `benchmark::DoNotOptimize` forcing memory stores. At least on x86, the hash values are stored in memory anyway, though. Probably fair.