### PR TITLE
Move CI to GitHub Runners

### DIFF
--- a/.github/workflows/build_run.yml
+++ b/.github/workflows/build_run.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - name: Install Clang
         run: |
-          add-apt-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main"
+          sudo add-apt-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main"
           sudo apt-get update
           sudo apt-get install --yes --no-install-recommends clang-15 lld-15 libclang-rt-15-dev
 

--- a/.github/workflows/build_run.yml
+++ b/.github/workflows/build_run.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: Build + Run
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -31,6 +31,11 @@ jobs:
       CXX: ${{matrix.compiler.cxx}}-${{matrix.compiler.version}}
 
     steps:
+      - name: Install Clang
+        uses: egor-tensin/setup-clang@v1
+        with:
+            version: 15
+
       - uses: actions/checkout@v3
 
       - name: Create Build Environment

--- a/.github/workflows/build_run.yml
+++ b/.github/workflows/build_run.yml
@@ -33,6 +33,7 @@ jobs:
     steps:
       - name: Install Clang
         run: |
+          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
           sudo add-apt-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main"
           sudo apt-get update
           sudo apt-get install --yes --no-install-recommends clang-15 lld-15 libclang-rt-15-dev

--- a/.github/workflows/build_run.yml
+++ b/.github/workflows/build_run.yml
@@ -33,8 +33,8 @@ jobs:
     steps:
       - name: Install Clang
         run: |
-          deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main
-          deb-src http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main
+          add-apt-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main"
+          sudo apt-get update
           sudo apt-get install --yes --no-install-recommends clang-15 lld-15 libclang-rt-15-dev
 
       - uses: actions/checkout@v3

--- a/.github/workflows/build_run.yml
+++ b/.github/workflows/build_run.yml
@@ -32,9 +32,7 @@ jobs:
 
     steps:
       - name: Install Clang
-        uses: egor-tensin/setup-clang@v1
-        with:
-            version: 15
+        run: sudo apt-get install --yes --no-install-recommends clang-15 libclang-rt-15-dev
 
       - uses: actions/checkout@v3
 

--- a/.github/workflows/build_run.yml
+++ b/.github/workflows/build_run.yml
@@ -32,7 +32,10 @@ jobs:
 
     steps:
       - name: Install Clang
-        run: sudo apt-get install --yes --no-install-recommends clang-15 libclang-rt-15-dev
+        run: |
+          deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main
+          deb-src http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main
+          sudo apt-get install --yes --no-install-recommends clang-15 lld-15 libclang-rt-15-dev
 
       - uses: actions/checkout@v3
 

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -8,12 +8,12 @@ on:
 
 jobs:
   format:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2
-    - uses: DoozyX/clang-format-lint-action@v0.14
+    - uses: DoozyX/clang-format-lint-action@v0.15
       with:
         source: 'benchmarks'
         extensions: 'hpp,cpp'
-        clangFormatVersion: 14
+        clangFormatVersion: 15

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -12,9 +12,14 @@ env:
 
 jobs:
   tidy:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
 
     steps:
+    - name: Install clang-tidy
+      run: |
+        sudo apt update
+        sudo apt -y install clang-tidy-15 
+
     - uses: actions/checkout@v2
 
     - name: Run clang-tidy


### PR DESCRIPTION
As this repo is public, we no longer want self-hosted runners. Move them to GitHub Actions Runners.