### PR TITLE
Add docker for AArch64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,17 @@
-FROM ubuntu:22.10
+# This is the basic docker image we use for our benchmarks.
+# We have a x86 version and a aarch64 version.
 
-RUN apt-get -q update
-# git required for CMake FetchContent_MakeAvailable
-RUN apt-get -q install -y clang-15 gcc-12 cmake git
+# x86 image: Build with --target=x86
+FROM amd64/ubuntu:22.10 as x86
+RUN apt-get -q update && apt-get -q install -y clang-15 gcc-12 cmake git
+ENV AUTOVEC_DB_COMPILER=clang++-15
+CMD ./scripts/docker_entrypoint.sh
+WORKDIR /autovec-db
 
+# AArch64 image: Build with --target=aarch64
+FROM arm64v8/ubuntu:22.10 as aarch64
+RUN apt-get -q update && apt-get -q install -y wget gnupg software-properties-common cmake git gcc-12
+RUN wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 17
+ENV AUTOVEC_DB_COMPILER=clang++-17
 CMD ./scripts/docker_entrypoint.sh
 WORKDIR /autovec-db

--- a/scripts/docker_entrypoint.sh
+++ b/scripts/docker_entrypoint.sh
@@ -1,8 +1,10 @@
 BUILD_DIR=./build-clang-release
 BENCH_ARGS="--benchmark_format=csv --benchmark_repetitions=10 --benchmark_report_aggregates_only=true"
 
+COMPILER="${AUTOVEC_DB_COMPILER:-clang++}"
+
 mkdir -p ${BUILD_DIR}
-CXX=clang++-15 cmake . -B ${BUILD_DIR} -DCMAKE_BUILD_TYPE=Release
+CXX=${COMPILER} cmake . -B ${BUILD_DIR} -DCMAKE_BUILD_TYPE=Release
 cmake --build ${BUILD_DIR} -j
 
 for BENCHMARK in hashing hash_bucket compressed_scan dictionary_scan compare_to_bitmask; do


### PR DESCRIPTION
We can now build two Docker images, one for x86 and one for AArch64. 

As of yesterday, llvm-17 contains both patches ([#1](https://reviews.llvm.org/rG267d6d665cf2379ebfcc65fa385a35529c83a7d0), [#2](https://reviews.llvm.org/rG3653722ce6d9bb44a42ffdce4e07080aa1928ddc)) needed for the paper. So we can use the latest dev-branch apt repository to use them. 

I'll upload them to Docker Hub with a correct manifest, so the command to run should stay the same and it automatically detects the correct CPU architecture.