### PR TITLE
Remove compare_to_bitmask from default benchmarks to run

### DIFF
--- a/scripts/docker_entrypoint.sh
+++ b/scripts/docker_entrypoint.sh
@@ -5,6 +5,6 @@ mkdir -p ${BUILD_DIR}
 CXX=clang++-15 cmake . -B ${BUILD_DIR} -DCMAKE_BUILD_TYPE=Release
 cmake --build ${BUILD_DIR} -j
 
-for BENCHMARK in hashing hash_bucket compressed_scan dictionary_scan compare_to_bitmask; do
+for BENCHMARK in hashing hash_bucket compressed_scan dictionary_scan; do
   ${BUILD_DIR}/${BENCHMARK} ${BENCH_ARGS} | tee ${BENCHMARK}.csv
 done


### PR DESCRIPTION
It takes too long and we don't really care about it, so why run it at all.