### PR TITLE
Add absolute performance of naive/scalar runs in plot for reference.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ $ pip3 install -r requirements.txt
 
 ### Plots
 
+Our scripts always generate a PNG and an SVG for each plot.
+By default, it will generate a version optimized for PNG.
+If you want to create the SVG plots used in the paper, set `AUTOVEC_DB_PLOTS=ON` in your environment variables.
+
 To generate a plot for a benchmark, run the following command:
 ```shell
 $ python3 scripts/<script_name>.py results/ /path/to/plot/dir

--- a/eval/scripts/common.py
+++ b/eval/scripts/common.py
@@ -29,6 +29,7 @@ APPLE_GREY = '#555555'
 
 DEFAULT_X86_ARCH = 'icelake'
 
+NAIVE_PERF_TEXT = {"rotation": 90, "ha": 'center', "va": 'bottom'}
 
 VARIANT_COLOR_BLACK_WHITE = {
     "naive": '#f0f0f0',
@@ -181,6 +182,10 @@ def SAVE_PLOT(plot_path, img_types=IMG_TYPES):
 
     plt.figure()
     print(f"To view new plots, run:\n\topen {' '.join(plot_paths)}")
+
+
+def IS_PAPER_PLOT():
+    return os.getenv("AUTOVEC_DB_PLOTS") == "ON"
 
 
 #######################################

--- a/eval/scripts/compressed_scan.py
+++ b/eval/scripts/compressed_scan.py
@@ -8,9 +8,18 @@ from common import *
 def plot_compressed_scan(ax, data):
     naive_perf = data[data['name'].str.contains('naive')]['runtime'].values[0]
 
+    max_diff = 1;
     for _, row in data.iterrows():
         variant = row['name']
-        ax.bar(variant, naive_perf / row['runtime'], **BAR(variant))
+        speedup = naive_perf / row['runtime']
+        ax.bar(variant, speedup, **BAR(variant))
+        max_diff = max(max_diff, speedup)
+
+    y_pos = 1 + (max_diff / 20)
+    if IS_PAPER_PLOT():
+        ax.text(0, y_pos, f"\\ms{{{naive_perf / 1000:.1f}}}", size=10, **NAIVE_PERF_TEXT)
+    else:
+        ax.text(0, y_pos, f"{naive_perf / 1000:.1f}ms", **NAIVE_PERF_TEXT)
 
     ax.tick_params(axis='x', which=u'both',length=0)
     ax.set_xticks(range(len(data)))

--- a/eval/scripts/dictionary_scan.py
+++ b/eval/scripts/dictionary_scan.py
@@ -8,10 +8,12 @@ from common import *
 def plot_dictionary_scan(ax, data):
     naive_perf = data[data['name'].str.contains('naive')]['runtime'].values[0]
 
+    max_diff = 1
     for _, row in data.iterrows():
         variant = row['name']
         speedup = naive_perf / row['runtime']
         bar_style = BAR(variant)
+        max_diff = max(speedup, max_diff)
 
         # Only plot with min. 10% diff to avoid plotting noise.
         plotting_patched = 'patched' in row and (naive_perf / row['patched']) > (speedup * 1.1)
@@ -30,6 +32,12 @@ def plot_dictionary_scan(ax, data):
 
     data['name'] = data['name'].str.replace(r"(avx512)-(\d+)-COMPRESSSTORE", r"vpcompressd-\2", regex=True)
     # data['name'] = data['name'].str.replace(r"-COMPRESSSTORE", "-compress")
+
+    y_pos = 1 + (max_diff / 20)
+    if IS_PAPER_PLOT():
+        ax.text(0, y_pos, f"\\ms{{{naive_perf / 1000:.1f}}}", size=10, **NAIVE_PERF_TEXT)
+    else:
+        ax.text(0, y_pos, f"{naive_perf / 1000:.1f}ms", **NAIVE_PERF_TEXT)
 
     ax.tick_params(axis='x', which=u'both',length=0)
     ax.set_xticks(range(len(data['name'])))

--- a/eval/scripts/hash_bucket.py
+++ b/eval/scripts/hash_bucket.py
@@ -23,6 +23,11 @@ def plot_hash_bucket(ax, data):
         # Plot regular bar.
         ax.bar(variant, speedup, **bar_style)
 
+    if IS_PAPER_PLOT():
+        ax.text(0, 1.2, f"\\us{{{int(naive_perf) / 1000 :.1f}}}", size=10, **NAIVE_PERF_TEXT)
+    else:
+        ax.text(0, 1.2, f"{int(naive_perf) / 1000 :.1f}us", **NAIVE_PERF_TEXT)
+
     ax.tick_params(axis='x', which=u'both', length=0)
     ax.set_xticks(range(len(data)))
     ax.set_xticklabels(data['name'], rotation=50, rotation_mode='anchor', ha='right')

--- a/eval/scripts/hashing.py
+++ b/eval/scripts/hashing.py
@@ -12,6 +12,14 @@ def plot_hashing(ax, data):
         variant = row['name']
         ax.bar(variant, naive_perf / row['runtime'], **BAR(variant))
 
+    scalar_perf = data[data['name'].str.contains('scalar')]['runtime'].values[0]
+    y_pos = 1.05 if (scalar_perf / naive_perf) < 2 else 0.3
+
+    if IS_PAPER_PLOT():
+        ax.text(0, y_pos, f"\\ns{{{int(scalar_perf)}}}", size=10, **NAIVE_PERF_TEXT)
+    else:
+        ax.text(0, y_pos, f"{int(scalar_perf)}ns", **NAIVE_PERF_TEXT)
+
     ax.tick_params(axis='x', which=u'both', length=0)
     ax.set_xticks(range(len(data)))
     ax.set_xticklabels(data['name'], rotation=60, rotation_mode='anchor', ha='right')


### PR DESCRIPTION
This is a bit annoying, as the SVG boundaries are calculated based on _some_ version of the rendered text. To keep the text short, I've added `\us`, `\ns`, and `\ms` commands to the paper, that we can use here. They will render this values correctly in the paper without shifting the boundaries.